### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/scripts/lib/renderer.mjs
+++ b/scripts/lib/renderer.mjs
@@ -23,6 +23,7 @@ export function contentTypeFor(filePath) {
 }
 
 export async function startStaticServer(rootDir) {
+    const safeRoot = path.resolve(rootDir);
     const server = http.createServer(async (req, res) => {
         try {
             const parsed = url.parse(req.url);
@@ -30,7 +31,13 @@ export async function startStaticServer(rootDir) {
             if (filePath === '/') {
                 filePath = '/README.md';
             }
-            const abs = path.join(rootDir, filePath);
+            // Resolve the requested path safely within the root directory
+            const abs = path.resolve(safeRoot, '.' + filePath);
+            if (!abs.startsWith(safeRoot + path.sep) && abs !== safeRoot) {
+                res.writeHead(403, { 'Content-Type': 'text/plain; charset=utf-8' });
+                res.end('Forbidden');
+                return;
+            }
             const data = await readFile(abs);
             res.writeHead(200, { 'Content-Type': contentTypeFor(abs) });
             res.end(data);


### PR DESCRIPTION
Potential fix for [https://github.com/Baskerville42/outage-data-ua/security/code-scanning/1](https://github.com/Baskerville42/outage-data-ua/security/code-scanning/1)

To fix the problem, the path derived from `req.url` must be validated/normalized before using it in `readFile`. Since this server is serving static files under a given `rootDir`, the right general approach is: resolve the requested path relative to `rootDir`, normalize it, and then ensure the resulting absolute path is still inside `rootDir`. If the check fails, respond with a 403 or 404 instead of reading the file.

The best minimal fix without changing existing functionality is:

1. Normalize the path using `path.resolve(rootDir, '.' + filePath)` (or similar) to collapse any `..` segments.
2. Ensure the normalized path is under `rootDir`, using a prefix check that accounts for directory boundaries.
3. Only call `readFile` on the validated path; otherwise, return an error.

We should keep the logic that maps `/` to `/README.md` and the existing `contentTypeFor` behavior, but replace the vulnerable `path.join` with a secure `path.resolve` + containment check. All changes occur in `startStaticServer` in `scripts/lib/renderer.mjs`; no new imports are required because `path` is already imported. We'll add a small helper inside `startStaticServer` (or inline code) to validate that the requested file stays within `rootDir`, and if not, send a 403 response.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
